### PR TITLE
Lever Actions updates

### DIFF
--- a/src/actions/lever/LeverActions.sol
+++ b/src/actions/lever/LeverActions.sol
@@ -359,8 +359,8 @@ abstract contract LeverActions {
         uint256 pathLength = pathPoolIds.length;
 
         IBalancerVault.BatchSwapStep[] memory swaps = new IBalancerVault.BatchSwapStep[](pathLength);
-        IAsset[] memory assets = new IAsset[](add(pathLength, uint256(1)));
-        int256[] memory limits = new int[](add(pathLength, uint256(1)));
+        IAsset[] memory assets = new IAsset[](add(pathLength, uint256(1))); // number of assets = number of swaps + 1
+        int256[] memory limits = new int[](add(pathLength, uint256(1))); // for each asset has an associated limit
 
         assets[pathLength] = IAsset(address(fiat));
         limits[0] = toInt256(maxUnderliersIn);

--- a/src/actions/lever/LeverActions.sol
+++ b/src/actions/lever/LeverActions.sol
@@ -288,7 +288,7 @@ abstract contract LeverActions {
         IBalancerVault.FundManagement memory funds;
         return abs(IBalancerVault(fiatBalancerVault).queryBatchSwap(
             IBalancerVault.SwapKind.GIVEN_IN, params.swaps, params.assets, funds
-        )[sub(params.assets.length,uint256(1))]);
+        )[sub(params.assets.length, uint256(1))]);
     }
     
     /// @notice Returns the required input amount of underliers for a given amount of FIAT to receive in exchange
@@ -326,7 +326,7 @@ abstract contract LeverActions {
         
         IBalancerVault.BatchSwapStep[] memory swaps = new IBalancerVault.BatchSwapStep[](pathLength);
         IAsset[] memory assets = new IAsset[](add(pathLength, uint256(1))); // number of assets = number of swaps + 1
-        assets[sub(assets.length,uint256(1))] =  IAsset(address(fiat));
+        assets[sub(assets.length, uint256(1))] = IAsset(address(fiat));
 
         for (uint256 i = 0; i < pathLength;) {
             uint256 nextAssetIndex;
@@ -343,7 +343,7 @@ abstract contract LeverActions {
         IBalancerVault.FundManagement memory funds;
         return abs(IBalancerVault(fiatBalancerVault).queryBatchSwap(
             IBalancerVault.SwapKind.GIVEN_IN, swaps, assets, funds
-        )[sub(assets.length,uint256(1))]);
+        )[sub(assets.length, uint256(1))]);
     }
 
     /// @notice Populates the SellFIATSwapParams struct used in the `_sellFIATExactIn` method
@@ -363,7 +363,7 @@ abstract contract LeverActions {
         IBalancerVault.BatchSwapStep[] memory swaps = new IBalancerVault.BatchSwapStep[](pathLength);
         IAsset[] memory assets = new IAsset[](add(pathLength, uint256(1))); // number of assets = number of swaps + 1
         int256[] memory limits = new int[](add(pathLength, uint256(1))); // for each asset has an associated limit
-        assets[0] =  IAsset(address(fiat));
+        assets[0] = IAsset(address(fiat));
         limits[pathLength] = -toInt256(minUnderliersOut);
 
         for (uint256 i = 0; i < pathLength;) {

--- a/src/actions/lever/LeverActions.sol
+++ b/src/actions/lever/LeverActions.sol
@@ -19,7 +19,9 @@ import {IBalancerVault, IAsset} from "../helper/ConvergentCurvePoolHelper.sol";
 // !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 
 /// @title LeverActions
-/// @notice
+/// @notice Base lever actions contract which meant to be inherited from from protocol specific implementations.
+/// This contract is only compatible with FIAT pairings on Balancer and supports swapping between FIAT and any other
+/// asset that's available through the Balancer Router.
 abstract contract LeverActions {
     /// ======== Custom Errors ======== ///
 

--- a/src/actions/lever/LeverActions.sol
+++ b/src/actions/lever/LeverActions.sol
@@ -268,7 +268,7 @@ abstract contract LeverActions {
         )[0]);
     }
 
-    /// ======== FIAT / Underlier Swap Off-Chain Helpers ======== ///
+    /// ======== FIAT / Underlier Swap Helpers ======== ///
 
     /// @notice Returns an amount of underliers for a given amount of FIAT
     /// @dev This method should be exclusively called off-chain for estimation.
@@ -287,7 +287,7 @@ abstract contract LeverActions {
         IBalancerVault.FundManagement memory funds;
         return abs(IBalancerVault(fiatBalancerVault).queryBatchSwap(
             IBalancerVault.SwapKind.GIVEN_IN, params.swaps, params.assets, funds
-        )[0]);
+        )[pathAssetsOut.length]);
     }
     
     /// @notice Returns the required input amount of underliers for a given amount of FIAT to receive in exchange
@@ -311,8 +311,6 @@ abstract contract LeverActions {
     }
 
     /// @notice Populates the SellFIATSwapParams struct used in the `_sellFIATExactIn` method
-    /// @dev This method should be exclusively called off-chain for estimation.
-    ///      `pathPoolIds` and `pathAssetsOut` must have the same length and be ordered from underlier to FIAT.
     /// @param pathPoolIds Balancer PoolIds for every step of the swap from underlier to FIAT
     /// @param pathAssetsOut Assets to be swapped at every step from underlier to FIAT (excluding FIAT)
     /// @param minUnderliersOut Min. amount of underlier to receive [underlierScale]
@@ -325,8 +323,8 @@ abstract contract LeverActions {
         uint256 pathLength = pathPoolIds.length;
        
         IBalancerVault.BatchSwapStep[] memory swaps = new IBalancerVault.BatchSwapStep[](pathLength);
-        IAsset[] memory assets = new IAsset[](add(pathLength, uint256(1))); // number of assets = number of swaps + 1
-        int256[] memory limits = new int[](add(pathLength, uint256(1))); // for each asset has an associated limit
+        IAsset[] memory assets = new IAsset[](add(pathLength, uint256(1)));
+        int256[] memory limits = new int[](add(pathLength, uint256(1)));
         assets[0] =  IAsset(address(fiat));
         limits[pathLength] = -toInt256(minUnderliersOut);
 
@@ -345,8 +343,6 @@ abstract contract LeverActions {
     }
 
     /// @notice Populates the BuyFIATSwapParams struct used in the `_buyFIATExactOut` method
-    /// @dev This method should be exclusively called off-chain for estimation.
-    ///      `pathPoolIds` and `pathAssetsIn` must have the same length and be ordered from underlier to FIAT.
     /// @param pathPoolIds Balancer PoolIds for every step of the swap from underlier to FIAT
     /// @param pathAssetsIn Assets to be swapped at every step from underlier to FIAT (excluding FIAT)
     /// @param maxUnderliersIn Max. amount of underlier to swap [underlierScale]
@@ -359,8 +355,8 @@ abstract contract LeverActions {
         uint256 pathLength = pathPoolIds.length;
 
         IBalancerVault.BatchSwapStep[] memory swaps = new IBalancerVault.BatchSwapStep[](pathLength);
-        IAsset[] memory assets = new IAsset[](add(pathLength, uint256(1))); // number of assets = number of swaps + 1
-        int256[] memory limits = new int[](add(pathLength, uint256(1))); // for each asset has an associated limit
+        IAsset[] memory assets = new IAsset[](add(pathLength, uint256(1)));
+        int256[] memory limits = new int[](add(pathLength, uint256(1)));
 
         assets[pathLength] = IAsset(address(fiat));
         limits[0] = toInt256(maxUnderliersIn);
@@ -369,8 +365,6 @@ abstract contract LeverActions {
             IBalancerVault.BatchSwapStep memory swap;
             unchecked {
                 swap = IBalancerVault.BatchSwapStep(
-                    // reverse the order such that last asset becomes assetIndexOut for the first swap
-                    // and the first asset becomes the assetIndexIn for the last swap
                     pathPoolIds[i], pathLength - i - 1, pathLength - i, 0, new bytes(0)
                 );
             }

--- a/src/actions/lever/LeverEPTActions.sol
+++ b/src/actions/lever/LeverEPTActions.sol
@@ -27,7 +27,6 @@ contract LeverEPTActions is Lever20Actions, ICreditFlashBorrower, IERC3156FlashB
 
     /// ======== Custom Errors ======== ///
 
-    error LeverEPTActions__buyCollateralAndIncreaseLever_zeroUpfrontUnderliers();
     error LeverEPTActions__onFlashLoan_unknownSender();
     error LeverEPTActions__onFlashLoan_unknownToken();
     error LeverEPTActions__onFlashLoan_nonZeroFee();
@@ -135,14 +134,16 @@ contract LeverEPTActions is Lever20Actions, ICreditFlashBorrower, IERC3156FlashB
         SellFIATSwapParams calldata fiatSwapParams,
         CollateralSwapParams calldata collateralSwapParams
     ) public {
-        if (upfrontUnderliers == 0) revert LeverEPTActions__buyCollateralAndIncreaseLever_zeroUpfrontUnderliers();
-        // if `collateralizer` is set to an external address then transfer the amount directly to Action contract
-        // requires `collateralizer` to have set an allowance for the proxy
-        if (collateralizer == address(this) || collateralizer == address(0)) {
+        if (upfrontUnderliers != 0) {
+            // if `collateralizer` is set to an external address then transfer the amount directly to Action contract
+            // requires `collateralizer` to have set an allowance for the proxy
+            if (collateralizer == address(this) || collateralizer == address(0)) {
             IERC20(collateralSwapParams.assetIn).safeTransfer(address(self), upfrontUnderliers);
-        } else {
+            } else {
             IERC20(collateralSwapParams.assetIn).safeTransferFrom(collateralizer, address(self), upfrontUnderliers);
+            }
         }
+
 
         codex.grantDelegate(self);
 

--- a/src/actions/lever/LeverEPTActions.sol
+++ b/src/actions/lever/LeverEPTActions.sol
@@ -144,7 +144,6 @@ contract LeverEPTActions is Lever20Actions, ICreditFlashBorrower, IERC3156FlashB
             }
         }
 
-
         codex.grantDelegate(self);
 
         bytes memory data = abi.encode(

--- a/src/actions/lever/LeverEPTActions.sol
+++ b/src/actions/lever/LeverEPTActions.sol
@@ -138,9 +138,9 @@ contract LeverEPTActions is Lever20Actions, ICreditFlashBorrower, IERC3156FlashB
             // if `collateralizer` is set to an external address then transfer the amount directly to Action contract
             // requires `collateralizer` to have set an allowance for the proxy
             if (collateralizer == address(this) || collateralizer == address(0)) {
-            IERC20(collateralSwapParams.assetIn).safeTransfer(address(self), upfrontUnderliers);
+                IERC20(collateralSwapParams.assetIn).safeTransfer(address(self), upfrontUnderliers);
             } else {
-            IERC20(collateralSwapParams.assetIn).safeTransferFrom(collateralizer, address(self), upfrontUnderliers);
+                IERC20(collateralSwapParams.assetIn).safeTransferFrom(collateralizer, address(self), upfrontUnderliers);
             }
         }
 

--- a/src/actions/lever/LeverEPTActions.sol
+++ b/src/actions/lever/LeverEPTActions.sol
@@ -27,6 +27,7 @@ contract LeverEPTActions is Lever20Actions, ICreditFlashBorrower, IERC3156FlashB
 
     /// ======== Custom Errors ======== ///
 
+    error LeverEPTActions__buyCollateralAndIncreaseLever_zeroUpfrontUnderliers();
     error LeverEPTActions__onFlashLoan_unknownSender();
     error LeverEPTActions__onFlashLoan_unknownToken();
     error LeverEPTActions__onFlashLoan_nonZeroFee();
@@ -134,6 +135,7 @@ contract LeverEPTActions is Lever20Actions, ICreditFlashBorrower, IERC3156FlashB
         SellFIATSwapParams calldata fiatSwapParams,
         CollateralSwapParams calldata collateralSwapParams
     ) public {
+        if (upfrontUnderliers == 0) revert LeverEPTActions__buyCollateralAndIncreaseLever_zeroUpfrontUnderliers();
         // if `collateralizer` is set to an external address then transfer the amount directly to Action contract
         // requires `collateralizer` to have set an allowance for the proxy
         if (collateralizer == address(this) || collateralizer == address(0)) {

--- a/src/actions/lever/LeverFYActions.sol
+++ b/src/actions/lever/LeverFYActions.sol
@@ -139,7 +139,6 @@ contract LeverFYActions is Lever20Actions, ICreditFlashBorrower, IERC3156FlashBo
             }
         }
 
-
         codex.grantDelegate(self);
 
         bytes memory data = abi.encode(

--- a/src/actions/lever/LeverFYActions.sol
+++ b/src/actions/lever/LeverFYActions.sol
@@ -25,6 +25,7 @@ contract LeverFYActions is Lever20Actions, ICreditFlashBorrower, IERC3156FlashBo
 
     /// ======== Custom Errors ======== ///
 
+    error LeverFYActions__buyCollateralAndIncreaseLever_zeroUpfrontUnderliers();
     error LeverFYActions__onFlashLoan_unknownSender();
     error LeverFYActions__onFlashLoan_unknownToken();
     error LeverFYActions__onFlashLoan_nonZeroFee();
@@ -129,6 +130,7 @@ contract LeverFYActions is Lever20Actions, ICreditFlashBorrower, IERC3156FlashBo
         SellFIATSwapParams calldata fiatSwapParams,
         CollateralSwapParams calldata collateralSwapParams
     ) public {
+        if (upfrontUnderliers == 0) revert LeverFYActions__buyCollateralAndIncreaseLever_zeroUpfrontUnderliers();
         // if `collateralizer` is set to an external address then transfer the amount directly to Action contract
         // requires `collateralizer` to have set an allowance for the proxy
         if (collateralizer == address(this) || collateralizer == address(0)) {

--- a/src/actions/lever/LeverFYActions.sol
+++ b/src/actions/lever/LeverFYActions.sol
@@ -133,9 +133,9 @@ contract LeverFYActions is Lever20Actions, ICreditFlashBorrower, IERC3156FlashBo
             // if `collateralizer` is set to an external address then transfer the amount directly to Action contract
             // requires `collateralizer` to have set an allowance for the proxy
             if (collateralizer == address(this) || collateralizer == address(0)) {
-            IERC20(collateralSwapParams.assetIn).safeTransfer(address(self), upfrontUnderliers);
+                IERC20(collateralSwapParams.assetIn).safeTransfer(address(self), upfrontUnderliers);
             } else {
-            IERC20(collateralSwapParams.assetIn).safeTransferFrom(collateralizer, address(self), upfrontUnderliers);
+                IERC20(collateralSwapParams.assetIn).safeTransferFrom(collateralizer, address(self), upfrontUnderliers);
             }
         }
 

--- a/src/actions/lever/LeverFYActions.sol
+++ b/src/actions/lever/LeverFYActions.sol
@@ -25,7 +25,6 @@ contract LeverFYActions is Lever20Actions, ICreditFlashBorrower, IERC3156FlashBo
 
     /// ======== Custom Errors ======== ///
 
-    error LeverFYActions__buyCollateralAndIncreaseLever_zeroUpfrontUnderliers();
     error LeverFYActions__onFlashLoan_unknownSender();
     error LeverFYActions__onFlashLoan_unknownToken();
     error LeverFYActions__onFlashLoan_nonZeroFee();
@@ -130,14 +129,16 @@ contract LeverFYActions is Lever20Actions, ICreditFlashBorrower, IERC3156FlashBo
         SellFIATSwapParams calldata fiatSwapParams,
         CollateralSwapParams calldata collateralSwapParams
     ) public {
-        if (upfrontUnderliers == 0) revert LeverFYActions__buyCollateralAndIncreaseLever_zeroUpfrontUnderliers();
-        // if `collateralizer` is set to an external address then transfer the amount directly to Action contract
-        // requires `collateralizer` to have set an allowance for the proxy
-        if (collateralizer == address(this) || collateralizer == address(0)) {
+        if (upfrontUnderliers != 0) {
+            // if `collateralizer` is set to an external address then transfer the amount directly to Action contract
+            // requires `collateralizer` to have set an allowance for the proxy
+            if (collateralizer == address(this) || collateralizer == address(0)) {
             IERC20(collateralSwapParams.assetIn).safeTransfer(address(self), upfrontUnderliers);
-        } else {
+            } else {
             IERC20(collateralSwapParams.assetIn).safeTransferFrom(collateralizer, address(self), upfrontUnderliers);
+            }
         }
+
 
         codex.grantDelegate(self);
 

--- a/src/actions/lever/LeverSPTActions.sol
+++ b/src/actions/lever/LeverSPTActions.sol
@@ -206,9 +206,9 @@ contract LeverSPTActions is Lever20Actions, ICreditFlashBorrower, IERC3156FlashB
             // if `collateralizer` is set to an external address then transfer the amount directly to Action contract
             // requires `collateralizer` to have set an allowance for the proxy
             if (collateralizer == address(this) || collateralizer == address(0)) {
-            IERC20(collateralSwapParams.assetIn).safeTransfer(address(self), upfrontUnderliers);
+                IERC20(collateralSwapParams.assetIn).safeTransfer(address(self), upfrontUnderliers);
             } else {
-            IERC20(collateralSwapParams.assetIn).safeTransferFrom(collateralizer, address(self), upfrontUnderliers);
+                IERC20(collateralSwapParams.assetIn).safeTransferFrom(collateralizer, address(self), upfrontUnderliers);
             }
         }
 

--- a/src/actions/lever/LeverSPTActions.sol
+++ b/src/actions/lever/LeverSPTActions.sol
@@ -202,7 +202,7 @@ contract LeverSPTActions is Lever20Actions, ICreditFlashBorrower, IERC3156FlashB
         SellFIATSwapParams calldata fiatSwapParams,
         CollateralSwapParams calldata collateralSwapParams
     ) public {
-         if (upfrontUnderliers != 0) {
+        if (upfrontUnderliers != 0) {
             // if `collateralizer` is set to an external address then transfer the amount directly to Action contract
             // requires `collateralizer` to have set an allowance for the proxy
             if (collateralizer == address(this) || collateralizer == address(0)) {
@@ -210,8 +210,7 @@ contract LeverSPTActions is Lever20Actions, ICreditFlashBorrower, IERC3156FlashB
             } else {
             IERC20(collateralSwapParams.assetIn).safeTransferFrom(collateralizer, address(self), upfrontUnderliers);
             }
-         }
-
+        }
 
         codex.grantDelegate(self);
 

--- a/src/actions/lever/LeverSPTActions.sol
+++ b/src/actions/lever/LeverSPTActions.sol
@@ -76,6 +76,7 @@ contract LeverSPTActions is Lever20Actions, ICreditFlashBorrower, IERC3156FlashB
 
     /// ======== Custom Errors ======== ///
 
+    error LeverSPTActions__buyCollateralAndIncreaseLever_zeroUpfrontUnderliers();
     error LeverSPTActions__onFlashLoan_unknownSender();
     error LeverSPTActions__onFlashLoan_unknownToken();
     error LeverSPTActions__onFlashLoan_nonZeroFee();
@@ -202,6 +203,7 @@ contract LeverSPTActions is Lever20Actions, ICreditFlashBorrower, IERC3156FlashB
         SellFIATSwapParams calldata fiatSwapParams,
         CollateralSwapParams calldata collateralSwapParams
     ) public {
+        if (upfrontUnderliers == 0) revert LeverSPTActions__buyCollateralAndIncreaseLever_zeroUpfrontUnderliers();
         // if `collateralizer` is set to an external address then transfer the amount directly to Action contract
         // requires `collateralizer` to have set an allowance for the proxy
         if (collateralizer == address(this) || collateralizer == address(0)) {

--- a/src/actions/lever/LeverSPTActions.sol
+++ b/src/actions/lever/LeverSPTActions.sol
@@ -76,7 +76,6 @@ contract LeverSPTActions is Lever20Actions, ICreditFlashBorrower, IERC3156FlashB
 
     /// ======== Custom Errors ======== ///
 
-    error LeverSPTActions__buyCollateralAndIncreaseLever_zeroUpfrontUnderliers();
     error LeverSPTActions__onFlashLoan_unknownSender();
     error LeverSPTActions__onFlashLoan_unknownToken();
     error LeverSPTActions__onFlashLoan_nonZeroFee();
@@ -203,14 +202,16 @@ contract LeverSPTActions is Lever20Actions, ICreditFlashBorrower, IERC3156FlashB
         SellFIATSwapParams calldata fiatSwapParams,
         CollateralSwapParams calldata collateralSwapParams
     ) public {
-        if (upfrontUnderliers == 0) revert LeverSPTActions__buyCollateralAndIncreaseLever_zeroUpfrontUnderliers();
-        // if `collateralizer` is set to an external address then transfer the amount directly to Action contract
-        // requires `collateralizer` to have set an allowance for the proxy
-        if (collateralizer == address(this) || collateralizer == address(0)) {
+         if (upfrontUnderliers != 0) {
+            // if `collateralizer` is set to an external address then transfer the amount directly to Action contract
+            // requires `collateralizer` to have set an allowance for the proxy
+            if (collateralizer == address(this) || collateralizer == address(0)) {
             IERC20(collateralSwapParams.assetIn).safeTransfer(address(self), upfrontUnderliers);
-        } else {
+            } else {
             IERC20(collateralSwapParams.assetIn).safeTransferFrom(collateralizer, address(self), upfrontUnderliers);
-        }
+            }
+         }
+
 
         codex.grantDelegate(self);
 

--- a/src/test/actions/rpc/LeverEPTActions.t.sol
+++ b/src/test/actions/rpc/LeverEPTActions.t.sol
@@ -13,7 +13,7 @@ import {Publican} from "../../../core/Publican.sol";
 import {FIAT} from "../../../core/FIAT.sol";
 import {Flash} from "../../../core/Flash.sol";
 import {Moneta} from "../../../core/Moneta.sol";
-import {toInt256, WAD, wdiv} from "../../../core/utils/Math.sol";
+import {toInt256, WAD, wdiv, wmul} from "../../../core/utils/Math.sol";
 
 import {PRBProxyFactory} from "proxy/contracts/PRBProxyFactory.sol";
 import {PRBProxy} from "proxy/contracts/PRBProxy.sol";
@@ -1244,5 +1244,36 @@ contract LeverEPTActions_RPC_tests is Test {
         assertGt(underlierUSDC.balanceOf(me), meInitialBalance);
         assertEq(ERC20(trancheUSDC_V4_yvUSDC_16SEP22).balanceOf(address(vault_yvUSDC_16SEP22)), vaultInitialBalance);
         assertEq(_collateral(address(vault_yvUSDC_16SEP22), address(userProxy)), initialCollateral);
+    }
+
+    function test_underlierToFIAT_18decimals_underlier() public {
+        uint256 underlierIn = 500 * WAD;
+
+        // Prepare arguments for preview method
+        pathPoolIds.push(fiatPoolId);
+        pathPoolIds.push(fiatPoolId);
+
+        pathAssetsIn.push(address(dai));
+        pathAssetsIn.push(address(underlierUSDC));
+        
+        uint fiatOut = leverActions.underlierToFIAT(pathPoolIds, pathAssetsIn, underlierIn);
+    
+        assertApproxEqAbs(underlierIn, fiatOut, 1 ether); 
+    }
+
+    function test_underlierToFIAT_6_decimals_underlier() public {
+        uint256 underlierIn = 500 * ONE_USDC;
+
+        // Prepare arguments for preview method
+        pathPoolIds.push(fiatPoolId);
+        pathPoolIds.push(fiatPoolId);
+
+        pathAssetsIn.push(address(underlierUSDC));
+        pathAssetsIn.push(address(dai));
+        
+        uint fiatOut = leverActions.underlierToFIAT(pathPoolIds, pathAssetsIn, underlierIn);
+
+        assertApproxEqAbs(underlierIn, wmul(fiatOut,vault_yvUSDC_16SEP22.underlierScale()), 1 * ONE_USDC); 
+        assertApproxEqAbs(fiatOut, wdiv(underlierIn,vault_yvUSDC_16SEP22.underlierScale()), 1 ether); 
     }
 }

--- a/src/test/actions/rpc/LeverFYActions.t.sol
+++ b/src/test/actions/rpc/LeverFYActions.t.sol
@@ -1735,4 +1735,46 @@ contract LeverFYActions_RPC_tests is Test {
         // closest to the maturity we get more underlier for same sPT
         assertGt(underlierBeforeMaturity, underlierNow);
     }
+
+    function test_fiatForUnderlier() public {
+        uint256 fiatOut = 500 * WAD;
+
+        // Prepare arguments for preview method
+        poolIds.push(fiatPoolId);
+        poolIds.push(fiatPoolId);
+
+        pathAssetsIn.push(address(usdc));
+        pathAssetsIn.push(address(dai));
+        
+        uint underlierIn = leverActions.fiatForUnderlier(poolIds, pathAssetsIn, fiatOut);
+
+        uint fiatIn = fiatOut;
+        
+        pathAssetsOut.push(address(dai));
+        pathAssetsOut.push(address(usdc));
+        
+        assertApproxEqAbs(underlierIn, wmul(fiatOut,fyUSDC2212Vault.tokenScale()), 2 * ONE_USDC);
+        assertApproxEqAbs(underlierIn, leverActions.fiatToUnderlier(poolIds, pathAssetsOut, fiatIn), 2 * ONE_USDC);
+    }
+
+    function test_fiatToUnderlier() public {
+        uint256 fiatIn = 500 * WAD;
+        
+        // Prepare arguments for preview method
+        poolIds.push(fiatPoolId);
+        poolIds.push(fiatPoolId);
+
+        pathAssetsOut.push(address(dai));
+        pathAssetsOut.push(address(usdc));
+
+        uint underlierOut = leverActions.fiatToUnderlier(poolIds, pathAssetsOut, fiatIn);
+
+        uint256 fiatOut = fiatIn;
+        
+        pathAssetsIn.push(address(usdc));
+        pathAssetsIn.push(address(dai));
+        
+        assertApproxEqAbs(underlierOut, wmul(fiatIn,fyUSDC2212Vault.tokenScale()), 2 * ONE_USDC);
+        assertApproxEqAbs(underlierOut, leverActions.fiatForUnderlier(poolIds, pathAssetsIn, fiatOut), 2 * ONE_USDC);
+    }
 }

--- a/src/test/actions/rpc/LeverFYActions.t.sol
+++ b/src/test/actions/rpc/LeverFYActions.t.sol
@@ -1861,7 +1861,7 @@ contract LeverFYActions_RPC_tests is Test {
             _getCollateralSwapParams(address(usdc), address(fyUSDC2212), 0, address(fyUSDC2212LP))
         );
 
-        assertGe(_collateral(address(fyUSDC2212Vault), address(userProxy)), wdiv(totalUnderlier+amount-fee, 10**IERC20Metadata(fyUSDC2212).decimals()));
+        assertGe(_collateral(address(fyUSDC2212Vault), address(userProxy)), wdiv(totalUnderlier + amount - fee, 10**IERC20Metadata(fyUSDC2212).decimals()));
         assertEq(_normalDebt(address(fyUSDC2212Vault), address(userProxy)), lendFIAT);
     }
 
@@ -1914,7 +1914,7 @@ contract LeverFYActions_RPC_tests is Test {
             _getCollateralSwapParams(address(dai), address(fyDAI2212), 0, address(fyDAI2212LP))
         );
 
-        assertGe(_collateral(address(fyDAI2212Vault), address(userProxy)), totalUnderlier+amount - fee);
+        assertGe(_collateral(address(fyDAI2212Vault), address(userProxy)), totalUnderlier + amount - fee);
         assertGe(_normalDebt(address(fyDAI2212Vault), address(userProxy)), lendFIAT);
     }
 }

--- a/src/test/actions/rpc/LeverSPTActions.t.sol
+++ b/src/test/actions/rpc/LeverSPTActions.t.sol
@@ -1407,4 +1407,37 @@ contract LeverSPTActions_RPC_tests is Test {
 
         assertApproxEqAbs(underlierOut, leverActions.fiatForUnderlier(pathPoolIds, pathAssetsIn, fiatOut), 4 ether);
     }
+
+        function testFail_buyCollateralAndIncreaseLever_simple() public {
+        uint256 lendFIAT = 1000 * WAD;
+        uint256 upfrontUnderlier = 0 * WAD;
+        uint256 totalUnderlier = 2000 * WAD;
+        uint256 fee = 50 * WAD;
+
+        // Prepare sell FIAT params
+        pathPoolIds.push(fiatPoolId);
+        pathPoolIds.push(fiatPoolId);
+        pathPoolIds.push(fiatPoolId);
+        pathPoolIds.push(fiatPoolId);
+        
+        pathAssetsOut.push(address(usdc));
+        pathAssetsOut.push(address(dai));
+        pathAssetsOut.push(address(usdc));
+        pathAssetsOut.push(address(dai));
+      
+        uint256 minUnderliersOut = totalUnderlier-upfrontUnderlier-fee;
+        uint256 deadline = block.timestamp + 10 days;
+       
+        _buyCollateralAndIncreaseLever(
+            address(maDAIVault),
+            me,
+            upfrontUnderlier,
+            lendFIAT,
+            leverActions.buildSellFIATSwapParams(pathPoolIds, pathAssetsOut, minUnderliersOut, deadline), 
+            // swap all for pTokens
+            _getCollateralSwapParams(address(dai), address(sP_maDAI), address(maDAIAdapter), type(uint256).max, 0)
+        );
+        
+      
+    }
 }

--- a/src/test/actions/rpc/LeverSPTActions.t.sol
+++ b/src/test/actions/rpc/LeverSPTActions.t.sol
@@ -1408,11 +1408,11 @@ contract LeverSPTActions_RPC_tests is Test {
         assertApproxEqAbs(underlierOut, leverActions.fiatForUnderlier(pathPoolIds, pathAssetsIn, fiatOut), 0.22 ether);
     }
 
-    function testFail_buyCollateralAndIncreaseLever_with_ZERO_upfrontUnderlier() public {
+    function test_buyCollateralAndIncreaseLever_with_ZERO_upfrontUnderlier() public {
         uint256 lendFIAT = 1000 * WAD;
         uint256 upfrontUnderlier = 0 * WAD;
-        uint256 totalUnderlier = 2000 * WAD;
-        uint256 fee = 50 * WAD;
+        uint256 totalUnderlier = 1000 * WAD;
+        uint256 fee = 10 * WAD;
 
         // Prepare sell FIAT params
         pathPoolIds.push(fiatPoolId);
@@ -1427,7 +1427,10 @@ contract LeverSPTActions_RPC_tests is Test {
       
         uint256 minUnderliersOut = totalUnderlier-upfrontUnderlier-fee;
         uint256 deadline = block.timestamp + 10 days;
-       
+
+        assertEq(_collateral(address(maDAIVault), address(userProxy)), 0);
+        assertEq(_normalDebt(address(maDAIVault), address(userProxy)), 0);
+
         _buyCollateralAndIncreaseLever(
             address(maDAIVault),
             me,
@@ -1437,5 +1440,8 @@ contract LeverSPTActions_RPC_tests is Test {
             // swap all for pTokens
             _getCollateralSwapParams(address(dai), address(sP_maDAI), address(maDAIAdapter), type(uint256).max, 0)
         );
+
+        assertGe(_collateral(address(maDAIVault), address(userProxy)), 1000 * WAD);
+        assertGe(_normalDebt(address(maDAIVault), address(userProxy)), 1000 * WAD);
     }
 }

--- a/src/test/actions/rpc/LeverSPTActions.t.sol
+++ b/src/test/actions/rpc/LeverSPTActions.t.sol
@@ -1408,7 +1408,7 @@ contract LeverSPTActions_RPC_tests is Test {
         assertApproxEqAbs(underlierOut, leverActions.fiatForUnderlier(pathPoolIds, pathAssetsIn, fiatOut), 4 ether);
     }
 
-        function testFail_buyCollateralAndIncreaseLever_simple() public {
+    function testFail_buyCollateralAndIncreaseLever_simple() public {
         uint256 lendFIAT = 1000 * WAD;
         uint256 upfrontUnderlier = 0 * WAD;
         uint256 totalUnderlier = 2000 * WAD;
@@ -1437,7 +1437,5 @@ contract LeverSPTActions_RPC_tests is Test {
             // swap all for pTokens
             _getCollateralSwapParams(address(dai), address(sP_maDAI), address(maDAIAdapter), type(uint256).max, 0)
         );
-        
-      
     }
 }

--- a/src/test/actions/rpc/LeverSPTActions.t.sol
+++ b/src/test/actions/rpc/LeverSPTActions.t.sol
@@ -1408,7 +1408,7 @@ contract LeverSPTActions_RPC_tests is Test {
         assertApproxEqAbs(underlierOut, leverActions.fiatForUnderlier(pathPoolIds, pathAssetsIn, fiatOut), 4 ether);
     }
 
-    function testFail_buyCollateralAndIncreaseLever_simple() public {
+    function testFail_buyCollateralAndIncreaseLever_with_ZERO_upfrontUnderlier() public {
         uint256 lendFIAT = 1000 * WAD;
         uint256 upfrontUnderlier = 0 * WAD;
         uint256 totalUnderlier = 2000 * WAD;

--- a/src/test/actions/rpc/LeverSPTActions.t.sol
+++ b/src/test/actions/rpc/LeverSPTActions.t.sol
@@ -1405,7 +1405,7 @@ contract LeverSPTActions_RPC_tests is Test {
         pathAssetsIn.push(address(dai));
         pathAssetsIn.push(address(usdc));
 
-        assertApproxEqAbs(underlierOut, leverActions.fiatForUnderlier(pathPoolIds, pathAssetsIn, fiatOut), 4 ether);
+        assertApproxEqAbs(underlierOut, leverActions.fiatForUnderlier(pathPoolIds, pathAssetsIn, fiatOut), 0.22 ether);
     }
 
     function testFail_buyCollateralAndIncreaseLever_with_ZERO_upfrontUnderlier() public {

--- a/src/test/actions/rpc/LeverSPTActions.t.sol
+++ b/src/test/actions/rpc/LeverSPTActions.t.sol
@@ -1384,7 +1384,8 @@ contract LeverSPTActions_RPC_tests is Test {
         
         pathAssetsOut.push(address(usdc));
         pathAssetsOut.push(address(dai));
-       
+
+        assertApproxEqAbs(underlierIn, fiatOut, 4 * WAD);
         assertApproxEqAbs(underlierIn, leverActions.fiatToUnderlier(pathPoolIds, pathAssetsOut, fiatIn), 4 ether);
     }
 
@@ -1405,6 +1406,7 @@ contract LeverSPTActions_RPC_tests is Test {
         pathAssetsIn.push(address(dai));
         pathAssetsIn.push(address(usdc));
 
+        assertApproxEqAbs(underlierOut, fiatIn, 5 * WAD);
         assertApproxEqAbs(underlierOut, leverActions.fiatForUnderlier(pathPoolIds, pathAssetsIn, fiatOut), 0.22 ether);
     }
 

--- a/src/test/actions/rpc/NoLossCollateralAuctionEPTActions.t.sol
+++ b/src/test/actions/rpc/NoLossCollateralAuctionEPTActions.t.sol
@@ -2,7 +2,6 @@
 pragma solidity ^0.8.4;
 
 import {Test} from "forge-std/Test.sol";
-import {console} from "forge-std/console.sol";
 import {IERC20} from "openzeppelin/contracts/token/ERC20/IERC20.sol";
 import {PRBProxyFactory} from "proxy/contracts/PRBProxyFactory.sol";
 import {PRBProxy} from "proxy/contracts/PRBProxy.sol";

--- a/src/test/actions/rpc/NoLossCollateralAuctionFCActions.t.sol
+++ b/src/test/actions/rpc/NoLossCollateralAuctionFCActions.t.sol
@@ -2,7 +2,6 @@
 pragma solidity ^0.8.4;
 
 import {Test} from "forge-std/Test.sol";
-import {console} from "forge-std/console.sol";
 import {IERC20} from "openzeppelin/contracts/token/ERC20/IERC20.sol";
 import {IERC1155} from "openzeppelin/contracts/token/ERC1155/IERC1155.sol";
 import {ERC1155Holder} from "openzeppelin/contracts/token/ERC1155/utils/ERC1155Holder.sol";

--- a/src/test/actions/rpc/NoLossCollateralAuctionFYActions.t.sol
+++ b/src/test/actions/rpc/NoLossCollateralAuctionFYActions.t.sol
@@ -2,7 +2,6 @@
 pragma solidity ^0.8.4;
 
 import {Test} from "forge-std/Test.sol";
-import {console} from "forge-std/console.sol";
 import {IERC20} from "openzeppelin/contracts/token/ERC20/IERC20.sol";
 import {PRBProxyFactory} from "proxy/contracts/PRBProxyFactory.sol";
 import {PRBProxy} from "proxy/contracts/PRBProxy.sol";
@@ -22,7 +21,6 @@ import {Vault20} from "../../../vaults/Vault.sol";
 import {VaultFactory} from "../../../vaults/VaultFactory.sol";
 import {VaultFY} from "../../../vaults/VaultFY.sol";
 import {NoLossCollateralAuctionFYActions} from "../../../actions/auction/NoLossCollateralAuctionFYActions.sol";
-
 
 contract NoLossCollateralAuctionFYActions_UnitTest is Test {
     Codex internal codex;

--- a/src/test/actions/rpc/NoLossCollateralAuctionSPTActions.t.sol
+++ b/src/test/actions/rpc/NoLossCollateralAuctionSPTActions.t.sol
@@ -2,7 +2,6 @@
 pragma solidity ^0.8.4;
 
 import {Test} from "forge-std/Test.sol";
-import {console} from "forge-std/console.sol";
 import {IERC20} from "openzeppelin/contracts/token/ERC20/IERC20.sol";
 import {PRBProxyFactory} from "proxy/contracts/PRBProxyFactory.sol";
 import {PRBProxy} from "proxy/contracts/PRBProxy.sol";
@@ -22,7 +21,6 @@ import {Vault20} from "../../../vaults/Vault.sol";
 import {VaultFactory} from "../../../vaults/VaultFactory.sol";
 import {VaultSPT} from "../../../vaults/VaultSPT.sol";
 import {NoLossCollateralAuctionSPTActions} from "../../../actions/auction/NoLossCollateralAuctionSPTActions.sol";
-
 
 interface IAdapter {
     function unwrapTarget(uint256 amount) external returns (uint256);

--- a/src/test/actions/rpc/VaultSPTmaDAI.t.sol
+++ b/src/test/actions/rpc/VaultSPTmaDAI.t.sol
@@ -27,7 +27,6 @@ import {VaultSPTActions} from "../../../actions/vault/VaultSPTActions.sol";
 import {IBalancerVault, IConvergentCurvePool} from "../../../actions/helper/ConvergentCurvePoolHelper.sol";
 
 import {Caller} from "../../../test/utils/Caller.sol";
-import {console} from "forge-std/console.sol";
 
 interface IAdapter {
     function unwrapTarget(uint256 amount) external returns (uint256);


### PR DESCRIPTION
Add revert if upfrontUnderlier is zero
Add check for assetDeltas returned in assets relative scales
Return underlier amount instead of FIAT in `fiatToUnderlier` off-chain method
Add `underlierToFIAT` method to LeverActions